### PR TITLE
Fix #2 and #3: Update address to uri and add documentation around support uri schema.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ This builds the plugin in `/build/rootfs`
 
 ###  Task manifest
 User need to provide following parameters in configuration for publisher:
-- `address` -  IP address with port number for RabbitMQ host,
+- `uri` -  AMQP URI scheme for connecting to server. URI supports the following form: "user:password@ip:port/vhost".
+           User, password, and vhost are optional. When not specified, the default values for RabbitMQ will be used.
 - `exchange_name` - name of exchange,
 - `routing_key` - routing key,
 - `exchange_type` -  type of exchange,
@@ -73,22 +74,16 @@ Example task manifest to use RabbitMQ plugin:
                     "password": "secret"
                 }
             },
-            "process": [
+            "publish": [
                 {
-                    "plugin_name": "passthru",
-                    "process": null,
-                    "publish": [
-                        {
-                            "plugin_name": "rabbitmq",
-                            "config": {
-                                "address": "127.0.0.1:5672",
-                                "exchange_name": "snap",
-                                "routing_key": "metrics",
-                                "exchange_type": "fanout",
-                                "durable" : true
-                            }
-                        }
-                    ]
+                    "plugin_name": "rabbitmq",
+                    "config": {
+                        "uri": "127.0.0.1:5672",
+                        "exchange_name": "snap",
+                        "routing_key": "metrics",
+                        "exchange_type": "fanout",
+                        "durable" : true
+                    }
                 }
             ]
         }

--- a/rmq/rmq.go
+++ b/rmq/rmq.go
@@ -47,7 +47,7 @@ func NewRmqPublisher() *rmqPublisher {
 
 const (
 	name       = "rabbitmq"
-	version    = 8
+	version    = 9
 	pluginType = plugin.PublisherPluginType
 )
 
@@ -67,7 +67,7 @@ func (rmq *rmqPublisher) Publish(contentType string, content []byte, config map[
 	}
 	err := publishDataToRmq(
 		metrics,
-		config["address"].(ctypes.ConfigValueStr).Value,
+		config["uri"].(ctypes.ConfigValueStr).Value,
 		config["exchange_name"].(ctypes.ConfigValueStr).Value,
 		config["routing_key"].(ctypes.ConfigValueStr).Value,
 		config["exchange_type"].(ctypes.ConfigValueStr).Value,
@@ -81,9 +81,9 @@ func (rmq *rmqPublisher) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
 	cp := cpolicy.New()
 	config := cpolicy.NewPolicyNode()
 
-	r1, err := cpolicy.NewStringRule("address", true)
+	r1, err := cpolicy.NewStringRule("uri", true)
 	handleErr(err)
-	r1.Description = "RabbitMQ Address (host:port)"
+	r1.Description = "RabbitMQ URI (user:password@ip:port/vhost)"
 	config.Add(r1)
 
 	r2, err := cpolicy.NewStringRule("exchange_name", true)
@@ -110,8 +110,8 @@ func (rmq *rmqPublisher) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
 	return cp, nil
 }
 
-func publishDataToRmq(metrics []plugin.MetricType, address string, exName string, rtKey string, exKind string, durable bool, logger *log.Logger) error {
-	conn, err := amqp.Dial("amqp://" + address)
+func publishDataToRmq(metrics []plugin.MetricType, uri string, exName string, rtKey string, exKind string, durable bool, logger *log.Logger) error {
+	conn, err := amqp.Dial("amqp://" + uri)
 	if err != nil {
 		logger.Printf("RMQ Publisher: cannot open connection, %s", err)
 		return err

--- a/rmq/rmq_integration_test.go
+++ b/rmq/rmq_integration_test.go
@@ -51,7 +51,7 @@ func TestRmqIntegration(t *testing.T) {
 	rmqPub := NewRmqPublisher()
 	cp, _ := rmqPub.GetConfigPolicy()
 	config := map[string]ctypes.ConfigValue{
-		"address":       ctypes.ConfigValueStr{Value: "127.0.0.1:5672"},
+		"uri":           ctypes.ConfigValueStr{Value: "127.0.0.1:5672"},
 		"exchange_name": ctypes.ConfigValueStr{Value: "snap"},
 		"routing_key":   ctypes.ConfigValueStr{Value: "metrics"},
 		"exchange_type": ctypes.ConfigValueStr{Value: "fanout"},

--- a/rmq/rmq_test.go
+++ b/rmq/rmq_test.go
@@ -60,7 +60,7 @@ func TestRabbitmqPlugin(t *testing.T) {
 
 			Convey("so processing of configuration without optional parameter should return correct values of parameters", func() {
 				testConfig := make(map[string]ctypes.ConfigValue)
-				testConfig["address"] = ctypes.ConfigValueStr{Value: "localhost:5672"}
+				testConfig["uri"] = ctypes.ConfigValueStr{Value: "localhost:5672"}
 				testConfig["exchange_name"] = ctypes.ConfigValueStr{Value: "snap"}
 				testConfig["exchange_type"] = ctypes.ConfigValueStr{Value: "fanout"}
 				testConfig["routing_key"] = ctypes.ConfigValueStr{Value: "metrics"}
@@ -71,7 +71,7 @@ func TestRabbitmqPlugin(t *testing.T) {
 				})
 
 				Convey("so parameters should have correct values", func() {
-					So((*cfg)["address"].(ctypes.ConfigValueStr).Value, ShouldEqual, "localhost:5672")
+					So((*cfg)["uri"].(ctypes.ConfigValueStr).Value, ShouldEqual, "localhost:5672")
 					So((*cfg)["exchange_name"].(ctypes.ConfigValueStr).Value, ShouldEqual, "snap")
 					So((*cfg)["exchange_type"].(ctypes.ConfigValueStr).Value, ShouldEqual, "fanout")
 					So((*cfg)["routing_key"].(ctypes.ConfigValueStr).Value, ShouldEqual, "metrics")
@@ -85,7 +85,7 @@ func TestRabbitmqPlugin(t *testing.T) {
 
 			Convey("so processing of configuration with optional parameter should return correct values of parameters", func() {
 				testConfig := make(map[string]ctypes.ConfigValue)
-				testConfig["address"] = ctypes.ConfigValueStr{Value: "localhost:5672"}
+				testConfig["uri"] = ctypes.ConfigValueStr{Value: "localhost:5672"}
 				testConfig["exchange_name"] = ctypes.ConfigValueStr{Value: "snap"}
 				testConfig["exchange_type"] = ctypes.ConfigValueStr{Value: "fanout"}
 				testConfig["routing_key"] = ctypes.ConfigValueStr{Value: "metrics"}
@@ -97,7 +97,7 @@ func TestRabbitmqPlugin(t *testing.T) {
 				})
 
 				Convey("so parameters should have correct values", func() {
-					So((*cfg)["address"].(ctypes.ConfigValueStr).Value, ShouldEqual, "localhost:5672")
+					So((*cfg)["uri"].(ctypes.ConfigValueStr).Value, ShouldEqual, "localhost:5672")
 					So((*cfg)["exchange_name"].(ctypes.ConfigValueStr).Value, ShouldEqual, "snap")
 					So((*cfg)["exchange_type"].(ctypes.ConfigValueStr).Value, ShouldEqual, "fanout")
 					So((*cfg)["routing_key"].(ctypes.ConfigValueStr).Value, ShouldEqual, "metrics")


### PR DESCRIPTION
Change address configuration item to uri and add documentation around supported uri schema for AMQP. The URI supports "user:pass@server:port/vhost". User, pass, and vhost are optional and will default to the defaults for a RabbitMQ instance. 